### PR TITLE
Colorize flags added to run and info subcommands.

### DIFF
--- a/swirlypy/colors.py
+++ b/swirlypy/colors.py
@@ -1,7 +1,5 @@
 # Set up the ansi escape codes.
 
-import sys
-
 class UnknownANSICodeException(Exception): pass
 
 class ANSI:

--- a/swirlypy/utils/swirlytool
+++ b/swirlypy/utils/swirlytool
@@ -32,9 +32,8 @@ def load_course(path):
         return None
 
 def setColorize(args):
-    """Set colorize flag according to specification in args if given.
-    If the flag is not specified in args, colorize only if running
-    in a tty."""
+    """Set colorize flag according to specification in args if given,
+    defaulting to False otherwise."""
     if(not hasattr(args, 'colorize') or args.colorize == None):
         colors.color.COLORIZE = False
     else:


### PR DESCRIPTION
Colorize flags, `-c` and `--colorize`, added to swirlytool subcommands, `run`, and `info`. If flags aren't specified, colorization defaults to False.
